### PR TITLE
Make Bumblezone Cosmic Crystal not get health scaled by Dungeon Difficulty by default

### DIFF
--- a/src/main/java/net/dungeon_difficulty/config/Default.java
+++ b/src/main/java/net/dungeon_difficulty/config/Default.java
@@ -51,7 +51,7 @@ public class Default {
         // Per Player Difficulty
         var perPlayerDifficulty = new Config.PerPlayerDifficulty();
         var perPlayerEntityModifier = new Config.EntityModifier();
-        perPlayerEntityModifier.entity_matches.entity_id_regex = Regex.ANY;
+        perPlayerEntityModifier.entity_matches.entity_id_regex = "^(?!the_bumblezone:cosmic_crystal_entity).*$";
         perPlayerEntityModifier.attributes = new Config.AttributeModifier[] {
                 createDamageMultiplier(0.2F, 0),
                 createHealthMultiplier(0.2F, 0F)


### PR DESCRIPTION
I have no idea if I set this up correctly. But if you don't feel this is a good idea, you can close this. The thought is by excluding my entity by default, it would help prevent players from experiencing the boss being scaled too much that it is unbeatable. Also helps set a example of an exclude regex. (I think the regex is right. Not sure...)