### PR TITLE
Feature: Attribute Modifier Tooltip Merging

### DIFF
--- a/src/main/java/net/dungeon_difficulty/config/ClientConfig.java
+++ b/src/main/java/net/dungeon_difficulty/config/ClientConfig.java
@@ -3,4 +3,5 @@ package net.dungeon_difficulty.config;
 public class ClientConfig {
     public boolean enable_overriding_enchantment_rarity = true;
     public boolean enable_scaled_items_rarity = true;
+    public boolean enable_enhanced_attribute_tooltips = true;
 }

--- a/src/main/java/net/dungeon_difficulty/logic/AttributeTooltipHandler.java
+++ b/src/main/java/net/dungeon_difficulty/logic/AttributeTooltipHandler.java
@@ -1,4 +1,4 @@
-package net.dungeon_difficulty.util;
+package net.dungeon_difficulty.logic;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
@@ -19,6 +19,8 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.minecraft.registry.Registries;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
@@ -27,10 +29,9 @@ import java.util.*;
 import java.util.function.Consumer;
 
 /**
- * Enhanced attribute tooltip system for Dungeon Difficulty, inspired by NeoForge's implementation
- * but adapted for Fabric and Yarn mappings.
+ * Merged Attribute Modifier tooltips, inspired by NeoForge.
  */
-public class AttributeTooltipHelper {
+public class AttributeTooltipHandler {
     private static final DecimalFormat FORMAT = new DecimalFormat("#.##", new DecimalFormatSymbols(Locale.ROOT));
     private static final Identifier FAKE_MERGED_ID = Identifier.of(DungeonDifficulty.MODID, "fake_merged_modifier");
 
@@ -44,6 +45,34 @@ public class AttributeTooltipHelper {
         Comparator.comparing(EntityAttributeModifier::operation)
             .thenComparing((EntityAttributeModifier a) -> -Math.abs(a.value()))
             .thenComparing(EntityAttributeModifier::id);
+
+    private static final Map<String, AttributeModifierSlot> KEY_SLOT_MAP = Util.make(new HashMap<>(), map -> {
+        map.put(Text.translatable("item.modifiers.mainhand").getString(), AttributeModifierSlot.MAINHAND);
+        map.put(Text.translatable("item.modifiers.offhand").getString(), AttributeModifierSlot.OFFHAND);
+        map.put(Text.translatable("item.modifiers.head").getString(), AttributeModifierSlot.HEAD);
+        map.put(Text.translatable("item.modifiers.chest").getString(), AttributeModifierSlot.CHEST);
+        map.put(Text.translatable("item.modifiers.legs").getString(), AttributeModifierSlot.LEGS);
+        map.put(Text.translatable("item.modifiers.feet").getString(), AttributeModifierSlot.FEET);
+        map.put(Text.translatable("item.modifiers.body").getString(), AttributeModifierSlot.BODY);
+    });
+
+    private static final Set<Identifier> BASE_ATTRIBUTE_IDS = Util.make(new HashSet<>(), set -> {
+        set.add(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_DAMAGE.value()));
+        set.add(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_SPEED.value()));
+        set.add(Registries.ATTRIBUTE.getId(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()));
+        set.add(Identifier.of("ranged_weapon", "damage"));
+        set.add(Identifier.of("ranged_weapon", "velocity"));
+        set.remove(null);
+    });
+
+    private static final Map<Identifier, Identifier> BASE_MODIFIER_IDS = Util.make(new HashMap<>(), map -> {
+        map.put(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_DAMAGE.value()), Item.BASE_ATTACK_DAMAGE_MODIFIER_ID);
+        map.put(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_SPEED.value()), Item.BASE_ATTACK_SPEED_MODIFIER_ID);
+        map.put(Registries.ATTRIBUTE.getId(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()), Identifier.ofVanilla("base_entity_reach"));
+        map.put(Identifier.of("ranged_weapon", "damage"), Identifier.of("ranged_weapon", "base_damage"));
+        map.put(Identifier.of("ranged_weapon", "velocity"), Identifier.of("ranged_weapon", "base_velocity"));
+        map.remove(null);
+    });
 
     public static boolean isDetailedView() {
         return DungeonDifficulty.clientConfig.value.enable_enhanced_attribute_tooltips && Screen.hasShiftDown();
@@ -102,32 +131,15 @@ public class AttributeTooltipHelper {
      */
     private static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> sortedMap() {
         return TreeMultimap.create(
-            Comparator.comparing(e -> e.getKey().toString()), // Compare attributes by registry key
+            Comparator.comparing(e -> e.getKey().toString()),
             ATTRIBUTE_MODIFIER_COMPARATOR
         );
     }
 
-    /**
-     * Get all modifiers for a slot, sorted by attribute and modifier
-     */
     private static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getSortedModifiers(ItemStack stack, AttributeModifierSlot slot) {
         Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = sortedMap();
 
-        AttributeModifiersComponent component = stack.getOrDefault(
-                DataComponentTypes.ATTRIBUTE_MODIFIERS, 
-                AttributeModifiersComponent.DEFAULT
-        );
-        
-        // This is probably not necessary, but I don't think it can hurt
-        if (component.modifiers().isEmpty()) {
-            component = stack.getItem().getAttributeModifiers();
-            
-            if (component == null) {
-                component = AttributeModifiersComponent.DEFAULT;
-            }
-        }
-
-        component.applyModifiers(slot, (attributeHolder, modifier) -> {
+        stack.applyAttributeModifier(slot, (attributeHolder, modifier) -> {
             if (attributeHolder != null && modifier != null) {
                 map.put(attributeHolder, modifier);
             }
@@ -317,7 +329,6 @@ public class AttributeTooltipHelper {
         if (isBaseModifier(attribute, modifier)) {
             return BASE_COLOR;
         }
-
         if (isBaseAttribute(attribute) && modifier.id().equals(FAKE_MERGED_ID)) {
             return MERGED_BASE_COLOR;
         }
@@ -325,10 +336,21 @@ public class AttributeTooltipHelper {
     }
 
     private static boolean isBaseAttribute(EntityAttribute attribute) {
-        return attribute == EntityAttributes.GENERIC_ATTACK_DAMAGE.value() ||
-               attribute == EntityAttributes.GENERIC_ATTACK_SPEED.value() ||
-               attribute == EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value();
+        Identifier id = Registries.ATTRIBUTE.getId(attribute);
+        return id != null && BASE_ATTRIBUTE_IDS.contains(id);
     }
+
+    private static boolean isBaseModifier(EntityAttribute attribute, EntityAttributeModifier modifier) {
+        Identifier baseId = getBaseModifierId(attribute);
+        return modifier.id().equals(baseId);
+    }
+
+    @Nullable
+    private static Identifier getBaseModifierId(EntityAttribute attribute) {
+        Identifier id = Registries.ATTRIBUTE.getId(attribute);
+        return id != null ? BASE_MODIFIER_IDS.get(id) : null;
+    }
+
 
     private static MutableText listHeader() {
         return Text.literal(" \u2507 ").formatted(Formatting.GRAY);
@@ -349,29 +371,11 @@ public class AttributeTooltipHelper {
         }
         return result;
     }
-    
-    /**
-     * TODO: Improve logic, this is pretty fragile (and ugly)
-     */
+
     @Nullable
     private static AttributeModifierSlot getSlotFromText(Text text) {
         String content = text.getString();
-
-        if (content.equals(Text.translatable("item.modifiers.mainhand").getString())) {
-            return AttributeModifierSlot.MAINHAND;
-        } else if (content.equals(Text.translatable("item.modifiers.offhand").getString())) {
-            return AttributeModifierSlot.OFFHAND;
-        } else if (content.equals(Text.translatable("item.modifiers.head").getString())) {
-            return AttributeModifierSlot.HEAD;
-        } else if (content.equals(Text.translatable("item.modifiers.chest").getString())) {
-            return AttributeModifierSlot.CHEST;
-        } else if (content.equals(Text.translatable("item.modifiers.legs").getString())) {
-            return AttributeModifierSlot.LEGS;
-        } else if (content.equals(Text.translatable("item.modifiers.feet").getString())) {
-            return AttributeModifierSlot.FEET;
-        }
-        
-        return null;
+        return KEY_SLOT_MAP.get(content);
     }
 
     private static int countAttributeLines(List<Text> tooltip, int startIndex) {
@@ -383,30 +387,14 @@ public class AttributeTooltipHelper {
             if (line.isEmpty() || getSlotFromText(Text.literal(line)) != null) {
                 break;
             }
-            
+
             // This looks like an attribute line
             count++;
         }
-        
+
         return count;
     }
 
-    private static boolean isBaseModifier(EntityAttribute attribute, EntityAttributeModifier modifier) {
-        Identifier baseId = getBaseModifierId(attribute);
-        return modifier.id().equals(baseId);
-    }
-
-    @Nullable
-    private static Identifier getBaseModifierId(EntityAttribute attribute) {
-        if (attribute == EntityAttributes.GENERIC_ATTACK_DAMAGE.value()) {
-            return Item.BASE_ATTACK_DAMAGE_MODIFIER_ID;
-        } else if (attribute == EntityAttributes.GENERIC_ATTACK_SPEED.value()) {
-            return Item.BASE_ATTACK_SPEED_MODIFIER_ID;
-        } else if (attribute == EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()) {
-            return Identifier.ofVanilla("base_entity_reach");
-        }
-        return null;
-    }
 
     private static boolean hasEnhanceableAttributeModifiers(ItemStack stack) {
         if (!DungeonDifficulty.clientConfig.value.enable_enhanced_attribute_tooltips) {

--- a/src/main/java/net/dungeon_difficulty/logic/AttributeTooltipHandler.java
+++ b/src/main/java/net/dungeon_difficulty/logic/AttributeTooltipHandler.java
@@ -61,7 +61,7 @@ public class AttributeTooltipHandler {
         set.add(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_SPEED.value()));
         set.add(Registries.ATTRIBUTE.getId(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()));
         set.add(Identifier.of("ranged_weapon", "damage"));
-        set.add(Identifier.of("ranged_weapon", "velocity"));
+        set.add(Identifier.of("ranged_weapon", "pull_time"));
         set.remove(null);
     });
 
@@ -70,7 +70,7 @@ public class AttributeTooltipHandler {
         map.put(Registries.ATTRIBUTE.getId(EntityAttributes.GENERIC_ATTACK_SPEED.value()), Item.BASE_ATTACK_SPEED_MODIFIER_ID);
         map.put(Registries.ATTRIBUTE.getId(EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()), Identifier.ofVanilla("base_entity_reach"));
         map.put(Identifier.of("ranged_weapon", "damage"), Identifier.of("ranged_weapon", "base_damage"));
-        map.put(Identifier.of("ranged_weapon", "velocity"), Identifier.of("ranged_weapon", "base_velocity"));
+        map.put(Identifier.of("ranged_weapon", "pull_time"), Identifier.of("ranged_weapon", "base_pull_time"));
         map.remove(null);
     });
 

--- a/src/main/java/net/dungeon_difficulty/logic/ItemScaling.java
+++ b/src/main/java/net/dungeon_difficulty/logic/ItemScaling.java
@@ -186,47 +186,37 @@ public class ItemScaling {
                 }
                 for (var attribute: affectedAttributes) {
                     var baseline = addValuesOf(attributesComponents, slot, attribute);
-                    var value = baseline.value;
-                    value = attributeBoost.getValue().apply((float) value);
+                    var baseValue = baseline.value;
+                    var boostedValue = attributeBoost.getValue().apply((float) baseValue);
+                    var boostAmount = boostedValue - baseValue;
                     if (roundingUnit != null) {
-                        value = MathHelper.round(value, roundingUnit);
+                        boostAmount = MathHelper.round(boostAmount, roundingUnit);
                     }
-
-                    results.get(slot).put(attribute, new ScaledAttributeResult(value));
+                    if (boostAmount != 0) {
+                        results.get(slot).put(attribute, new ScaledAttributeResult(boostAmount));
+                    }
                 }
             }
         }
 
-
         var newAttributeComponent = AttributeModifiersComponent.builder();
         for (var slot: slots) {
-            var slotResults = results.get(slot);
             attributesComponents.applyModifiers(slot, (attribute, modifier) -> {
-                var result = slotResults.get(attribute);
-                if (modifier.operation() == EntityAttributeModifier.Operation.ADD_VALUE
-                    && result != null) {
-                    var id = modifier.id();
-                    newAttributeComponent.add(
-                            attribute,
-                            new EntityAttributeModifier(id, result.value, EntityAttributeModifier.Operation.ADD_VALUE),
-                            AttributeModifierSlot.forEquipmentSlot(slot));
-                } else {
-                    newAttributeComponent.add(
-                            attribute,
-                            modifier,
-                            AttributeModifierSlot.forEquipmentSlot(slot));
-                }
-                slotResults.remove(attribute);
+                newAttributeComponent.add(attribute, modifier, AttributeModifierSlot.forEquipmentSlot(slot));
             });
+
+            var slotResults = results.get(slot);
             // Remainder of slot results (newly added modifiers)
             for (var entry: slotResults.entrySet()) {
                 var attribute = entry.getKey();
                 var result = entry.getValue();
-                var id = Identifier.ofVanilla("dd.boost." + slot.asString());
-                newAttributeComponent.add(
-                        attribute,
-                        new EntityAttributeModifier(id, result.value, EntityAttributeModifier.Operation.ADD_VALUE),
-                        AttributeModifierSlot.forEquipmentSlot(slot));
+                if (result.value() != 0) {
+                    var id = Identifier.of(DungeonDifficulty.MODID, "dd.boost." + slot.asString() + "." + level);
+                    newAttributeComponent.add(
+                            attribute,
+                            new EntityAttributeModifier(id, result.value(), EntityAttributeModifier.Operation.ADD_VALUE),
+                            AttributeModifierSlot.forEquipmentSlot(slot));
+                }
             }
         }
 

--- a/src/main/java/net/dungeon_difficulty/mixin/ItemStackMixin.java
+++ b/src/main/java/net/dungeon_difficulty/mixin/ItemStackMixin.java
@@ -1,28 +1,28 @@
 package net.dungeon_difficulty.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.dungeon_difficulty.DungeonDifficulty;
 import net.dungeon_difficulty.logic.RarityHelper;
+import net.dungeon_difficulty.util.AttributeTooltipHelper;
 import net.minecraft.component.ComponentType;
 import net.minecraft.component.DataComponentTypes;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.attribute.EntityAttribute;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.dungeon_difficulty.logic.ItemScaling;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import net.minecraft.util.Rarity;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.UUID;
+import java.util.List;
 import java.util.function.Consumer;
 
 @Mixin(ItemStack.class)
@@ -63,5 +63,19 @@ public class ItemStackMixin {
             }
         }
         original.call(instance, componentType, context, textConsumer, type);
+    }
+
+    @ModifyReturnValue(
+            method = "getTooltip",
+            at = @At("RETURN")
+    )
+    private List<Text> applyEnhancedAttributeTooltips(List<Text> tooltip, Item.TooltipContext context, @Nullable PlayerEntity player, TooltipType type) {
+        if (!DungeonDifficulty.clientConfig.value.enable_enhanced_attribute_tooltips) {
+            return tooltip;
+        }
+
+        ItemStack stack = (ItemStack)(Object)this;
+        AttributeTooltipHelper.processTooltip(stack, tooltip, player);
+        return tooltip;
     }
 }

--- a/src/main/java/net/dungeon_difficulty/mixin/ItemStackMixin.java
+++ b/src/main/java/net/dungeon_difficulty/mixin/ItemStackMixin.java
@@ -5,7 +5,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.dungeon_difficulty.DungeonDifficulty;
 import net.dungeon_difficulty.logic.RarityHelper;
-import net.dungeon_difficulty.util.AttributeTooltipHelper;
+import net.dungeon_difficulty.logic.AttributeTooltipHandler;
 import net.minecraft.component.ComponentType;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.attribute.EntityAttribute;
@@ -25,7 +25,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 import java.util.function.Consumer;
 
-@Mixin(ItemStack.class)
+@Mixin(value = ItemStack.class, priority = 1100)
 public class ItemStackMixin {
     private ItemStack itemStack() {
         return (ItemStack) (Object) this;
@@ -75,7 +75,7 @@ public class ItemStackMixin {
         }
 
         ItemStack stack = (ItemStack)(Object)this;
-        AttributeTooltipHelper.processTooltip(stack, tooltip, player);
+        AttributeTooltipHandler.processTooltip(stack, tooltip, player);
         return tooltip;
     }
 }

--- a/src/main/java/net/dungeon_difficulty/util/AttributeTooltipHelper.java
+++ b/src/main/java/net/dungeon_difficulty/util/AttributeTooltipHelper.java
@@ -1,0 +1,460 @@
+package net.dungeon_difficulty.util;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.TreeMultimap;
+import net.dungeon_difficulty.DungeonDifficulty;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.AttributeModifierSlot;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributeModifier.Operation;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * Enhanced attribute tooltip system for Dungeon Difficulty, inspired by NeoForge's implementation
+ * but adapted for Fabric and Yarn mappings.
+ */
+public class AttributeTooltipHelper {
+    private static final DecimalFormat FORMAT = new DecimalFormat("#.##", new DecimalFormatSymbols(Locale.ROOT));
+    private static final Identifier FAKE_MERGED_ID = Identifier.of(DungeonDifficulty.MODID, "fake_merged_modifier");
+
+    private static final Formatting BASE_COLOR = Formatting.DARK_GREEN;
+    private static final Formatting MERGED_BASE_COLOR = Formatting.GOLD;
+    private static final int MERGED_MODIFIER_COLOR = 7699710; // Light Blue
+    private static final Formatting POSITIVE_COLOR = Formatting.BLUE;
+    private static final Formatting NEGATIVE_COLOR = Formatting.RED;
+
+    private static final Comparator<EntityAttributeModifier> ATTRIBUTE_MODIFIER_COMPARATOR = 
+        Comparator.comparing(EntityAttributeModifier::operation)
+            .thenComparing((EntityAttributeModifier a) -> -Math.abs(a.value()))
+            .thenComparing(EntityAttributeModifier::id);
+
+    public static boolean isDetailedView() {
+        return DungeonDifficulty.clientConfig.value.enable_enhanced_attribute_tooltips && Screen.hasShiftDown();
+    }
+
+    public static void processTooltip(ItemStack stack, List<Text> tooltip, @Nullable PlayerEntity player) {
+        if (!hasEnhanceableAttributeModifiers(stack)) {
+            return;
+        }
+
+        List<AttributeSection> sections = findAttributeSections(tooltip);
+        if (sections.isEmpty()) {
+            return;
+        }
+
+        List<Text> newTooltip = new ArrayList<>();
+        int currentIndex = 0;
+        for (AttributeSection section : sections) {
+            int sectionStart = section.startIndex;
+            while (currentIndex < sectionStart) {
+                newTooltip.add(tooltip.get(currentIndex++));
+            }
+            newTooltip.add(tooltip.get(currentIndex++));
+            processAttributeSection(stack, tooltip, newTooltip, currentIndex, section.lineCount, section.slot, player);
+            currentIndex += section.lineCount;
+        }
+
+        while (currentIndex < tooltip.size()) {
+            newTooltip.add(tooltip.get(currentIndex++));
+        }
+        tooltip.clear();
+        tooltip.addAll(newTooltip);
+    }
+
+    private static void processAttributeSection(
+            ItemStack stack,
+            List<Text> originalTooltip, 
+            List<Text> newTooltip,
+            int startIndex, 
+            int lineCount, 
+            AttributeModifierSlot slot,
+            @Nullable PlayerEntity player) {
+
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> modifiers = getSortedModifiers(stack, slot);
+        if (modifiers.isEmpty()) {
+            for (int i = 0; i < lineCount; i++) {
+                newTooltip.add(originalTooltip.get(startIndex + i));
+            }
+            return;
+        }
+        applyTextFor(stack, newTooltip::add, modifiers, player);
+    }
+
+    /**
+     * Creates a sorted TreeMultimap to ensure consistent ordering of modifiers
+     */
+    private static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> sortedMap() {
+        return TreeMultimap.create(
+            Comparator.comparing(e -> e.getKey().toString()), // Compare attributes by registry key
+            ATTRIBUTE_MODIFIER_COMPARATOR
+        );
+    }
+
+    /**
+     * Get all modifiers for a slot, sorted by attribute and modifier
+     */
+    private static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getSortedModifiers(ItemStack stack, AttributeModifierSlot slot) {
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = sortedMap();
+
+        AttributeModifiersComponent component = stack.getOrDefault(
+                DataComponentTypes.ATTRIBUTE_MODIFIERS, 
+                AttributeModifiersComponent.DEFAULT
+        );
+        
+        // This is probably not necessary, but I don't think it can hurt
+        if (component.modifiers().isEmpty()) {
+            component = stack.getItem().getAttributeModifiers();
+            
+            if (component == null) {
+                component = AttributeModifiersComponent.DEFAULT;
+            }
+        }
+
+        component.applyModifiers(slot, (attributeHolder, modifier) -> {
+            if (attributeHolder != null && modifier != null) {
+                map.put(attributeHolder, modifier);
+            }
+        });
+        
+        return map;
+    }
+
+    private static void applyTextFor(
+            ItemStack stack,
+            Consumer<Text> tooltip, 
+            Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> modifierMap,
+            @Nullable PlayerEntity player) {
+        
+        if (modifierMap.isEmpty()) {
+            return;
+        }
+
+        Map<RegistryEntry<EntityAttribute>, BaseModifier> baseModifiers = new IdentityHashMap<>();
+
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> remainingModifiers = sortedMap();
+        remainingModifiers.putAll(modifierMap);
+
+        var it = remainingModifiers.entries().iterator();
+        while (it.hasNext()) {
+            var entry = it.next();
+            RegistryEntry<EntityAttribute> attr = entry.getKey();
+            EntityAttributeModifier modifier = entry.getValue();
+            
+            if (isBaseModifier(attr.value(), modifier)) {
+                baseModifiers.put(attr, new BaseModifier(modifier, new ArrayList<>()));
+                it.remove();
+            }
+        }
+
+        it = remainingModifiers.entries().iterator();
+        while (it.hasNext()) {
+            var entry = it.next();
+            RegistryEntry<EntityAttribute> attr = entry.getKey();
+            EntityAttributeModifier modifier = entry.getValue();
+
+            if (isBaseAttribute(attr.value())) {
+                BaseModifier base = baseModifiers.get(attr);
+                if (base != null) {
+                    base.children.add(modifier);
+                    it.remove();
+                }
+            }
+        }
+
+        for (var entry : baseModifiers.entrySet()) {
+            RegistryEntry<EntityAttribute> attr = entry.getKey();
+            BaseModifier baseModifier = entry.getValue();
+
+            double entityBase = player == null ? 0 : player.getAttributeBaseValue(attr);
+            double base = baseModifier.base.value() + entityBase;
+            final double rawBase = base;
+            double amount = base;
+
+            for (EntityAttributeModifier modifier : baseModifier.children) {
+                switch (modifier.operation()) {
+                    case ADD_VALUE:
+                        base = amount = amount + modifier.value();
+                        break;
+                    case ADD_MULTIPLIED_BASE:
+                        amount += modifier.value() * rawBase;
+                        break;
+                    case ADD_MULTIPLIED_TOTAL:
+                        amount *= 1.0 + modifier.value();
+                        break;
+                }
+            }
+
+            boolean isMerged = !baseModifier.children.isEmpty();
+            
+            MutableText text = createBaseComponent(attr.value(), amount, entityBase, isMerged);
+            tooltip.accept(Text.literal(" ").append(text.formatted(isMerged ? MERGED_BASE_COLOR : BASE_COLOR)));
+            
+            if (isDetailedView() && isMerged) {
+                text = createBaseComponent(attr.value(), rawBase, entityBase, false);
+                tooltip.accept(listHeader().append(text.formatted(BASE_COLOR)));
+                
+                for (EntityAttributeModifier modifier : baseModifier.children) {
+                    tooltip.accept(listHeader().append(createModifierComponent(attr.value(), modifier)));
+                }
+            }
+        }
+
+        for (RegistryEntry<EntityAttribute> attr : remainingModifiers.keySet()) {
+            if (baseModifiers.containsKey(attr)) {
+                continue;
+            }
+            Collection<EntityAttributeModifier> modifiers = remainingModifiers.get(attr);
+            boolean isBaseAttr = isBaseAttribute(attr.value());
+            if (modifiers.size() > 1) {
+                Map<Operation, MergedModifierData> mergeData = new EnumMap<>(Operation.class);
+                
+                for (EntityAttributeModifier modifier : modifiers) {
+                    if (modifier.value() == 0) {
+                        continue;
+                    }
+                    
+                    MergedModifierData data = mergeData.computeIfAbsent(modifier.operation(), op -> new MergedModifierData());
+                    if (data.sum != 0) {
+                        data.isMerged = true;
+                    }
+                    data.sum += modifier.value();
+                    data.children.add(modifier);
+                }
+                for (Operation op : Operation.values()) {
+                    MergedModifierData data = mergeData.get(op);
+                    if (data == null || data.sum == 0) {
+                        continue;
+                    }
+                    if (data.isMerged) {
+                        EntityAttributeModifier fakeModifier = new EntityAttributeModifier(
+                            FAKE_MERGED_ID, data.sum, op);
+                        
+                        MutableText modComponent = createModifierComponent(attr.value(), fakeModifier);
+                        if (isBaseAttr) {
+                            tooltip.accept(modComponent.formatted(MERGED_BASE_COLOR));
+                        } else {
+                            tooltip.accept(modComponent.styled(style -> style.withColor(MERGED_MODIFIER_COLOR)));
+                        }
+                        
+                        if (isDetailedView()) {
+                            for (EntityAttributeModifier mod : data.children) {
+                                tooltip.accept(listHeader().append(createModifierComponent(attr.value(), mod)));
+                            }
+                        }
+                    } else {
+                        EntityAttributeModifier fakeModifier = new EntityAttributeModifier(
+                            FAKE_MERGED_ID, data.sum, op);
+                        
+                        tooltip.accept(createModifierComponent(attr.value(), fakeModifier));
+                    }
+                }
+            } else {
+                for (EntityAttributeModifier modifier : modifiers) {
+                    if (modifier.value() != 0) {
+                        tooltip.accept(createModifierComponent(attr.value(), modifier));
+                    }
+                }
+            }
+        }
+    }
+
+    private static MutableText createBaseComponent(EntityAttribute attribute, double value, double entityBase, boolean merged) {
+        return Text.translatable("attribute.modifier.equals.0",
+            FORMAT.format(value),
+            Text.translatable(attribute.getTranslationKey()));
+    }
+
+    private static MutableText createModifierComponent(EntityAttribute attribute, EntityAttributeModifier modifier) {
+        double value = modifier.value();
+        boolean isPositive = value > 0;
+
+        String key = isPositive ? 
+            "attribute.modifier.plus." + modifier.operation().getId() : 
+            "attribute.modifier.take." + modifier.operation().getId();
+        String formattedValue = formatValue(attribute, value, modifier.operation());
+        MutableText component = Text.translatable(key,
+            formattedValue,
+            Text.translatable(attribute.getTranslationKey()));
+        if (!isBaseAttribute(attribute) && modifier.id().equals(FAKE_MERGED_ID)) {
+            return component.styled(style -> style.withColor(MERGED_MODIFIER_COLOR));
+        }
+        Formatting color = getModifierFormatting(attribute, modifier, isPositive);
+        return component.formatted(color);
+    }
+
+    private static String formatValue(EntityAttribute attribute, double value, Operation operation) {
+        double absValue = Math.abs(value);
+        
+        if (operation == Operation.ADD_VALUE) {
+            if (attribute == EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE) {
+                return FORMAT.format(absValue * 10); // Display as percentage x10
+            } else {
+                return FORMAT.format(absValue);
+            }
+        } else {
+            return FORMAT.format(absValue * 100);
+        }
+    }
+
+    private static Formatting getModifierFormatting(EntityAttribute attribute, EntityAttributeModifier modifier, boolean isPositive) {
+        if (isBaseModifier(attribute, modifier)) {
+            return BASE_COLOR;
+        }
+
+        if (isBaseAttribute(attribute) && modifier.id().equals(FAKE_MERGED_ID)) {
+            return MERGED_BASE_COLOR;
+        }
+        return isPositive ? POSITIVE_COLOR : NEGATIVE_COLOR;
+    }
+
+    private static boolean isBaseAttribute(EntityAttribute attribute) {
+        return attribute == EntityAttributes.GENERIC_ATTACK_DAMAGE.value() ||
+               attribute == EntityAttributes.GENERIC_ATTACK_SPEED.value() ||
+               attribute == EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value();
+    }
+
+    private static MutableText listHeader() {
+        return Text.literal(" \u2507 ").formatted(Formatting.GRAY);
+    }
+
+    private static List<AttributeSection> findAttributeSections(List<Text> tooltip) {
+        List<AttributeSection> result = new ArrayList<>();
+        for (int i = 0; i < tooltip.size(); i++) {
+            Text line = tooltip.get(i);
+            AttributeModifierSlot slot = getSlotFromText(line);
+            
+            if (slot != null) {
+                int numLines = countAttributeLines(tooltip, i + 1);
+                if (numLines > 0) {
+                    result.add(new AttributeSection(i, numLines, slot));
+                }
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * TODO: Improve logic, this is pretty fragile (and ugly)
+     */
+    @Nullable
+    private static AttributeModifierSlot getSlotFromText(Text text) {
+        String content = text.getString();
+
+        if (content.equals(Text.translatable("item.modifiers.mainhand").getString())) {
+            return AttributeModifierSlot.MAINHAND;
+        } else if (content.equals(Text.translatable("item.modifiers.offhand").getString())) {
+            return AttributeModifierSlot.OFFHAND;
+        } else if (content.equals(Text.translatable("item.modifiers.head").getString())) {
+            return AttributeModifierSlot.HEAD;
+        } else if (content.equals(Text.translatable("item.modifiers.chest").getString())) {
+            return AttributeModifierSlot.CHEST;
+        } else if (content.equals(Text.translatable("item.modifiers.legs").getString())) {
+            return AttributeModifierSlot.LEGS;
+        } else if (content.equals(Text.translatable("item.modifiers.feet").getString())) {
+            return AttributeModifierSlot.FEET;
+        }
+        
+        return null;
+    }
+
+    private static int countAttributeLines(List<Text> tooltip, int startIndex) {
+        int count = 0;
+        for (int i = startIndex; i < tooltip.size(); i++) {
+            String line = tooltip.get(i).getString();
+
+            // Stop if we hit an empty line or another section header
+            if (line.isEmpty() || getSlotFromText(Text.literal(line)) != null) {
+                break;
+            }
+            
+            // This looks like an attribute line
+            count++;
+        }
+        
+        return count;
+    }
+
+    private static boolean isBaseModifier(EntityAttribute attribute, EntityAttributeModifier modifier) {
+        Identifier baseId = getBaseModifierId(attribute);
+        return modifier.id().equals(baseId);
+    }
+
+    @Nullable
+    private static Identifier getBaseModifierId(EntityAttribute attribute) {
+        if (attribute == EntityAttributes.GENERIC_ATTACK_DAMAGE.value()) {
+            return Item.BASE_ATTACK_DAMAGE_MODIFIER_ID;
+        } else if (attribute == EntityAttributes.GENERIC_ATTACK_SPEED.value()) {
+            return Item.BASE_ATTACK_SPEED_MODIFIER_ID;
+        } else if (attribute == EntityAttributes.PLAYER_ENTITY_INTERACTION_RANGE.value()) {
+            return Identifier.ofVanilla("base_entity_reach");
+        }
+        return null;
+    }
+
+    private static boolean hasEnhanceableAttributeModifiers(ItemStack stack) {
+        if (!DungeonDifficulty.clientConfig.value.enable_enhanced_attribute_tooltips) {
+            return false;
+        }
+
+        AttributeModifiersComponent component = stack.getOrDefault(
+                DataComponentTypes.ATTRIBUTE_MODIFIERS, 
+                AttributeModifiersComponent.DEFAULT
+        );
+
+        return component.showInTooltip() && !component.modifiers().isEmpty();
+    }
+    
+    /**
+     * Stores a single base modifier and its children
+     */
+    private static class BaseModifier {
+        final EntityAttributeModifier base;
+        final List<EntityAttributeModifier> children;
+        
+        BaseModifier(EntityAttributeModifier base, List<EntityAttributeModifier> children) {
+            this.base = base;
+            this.children = children;
+        }
+    }
+    
+    /**
+     * Stores merged modifier data for a specific operation
+     */
+    private static class MergedModifierData {
+        double sum = 0;
+        boolean isMerged = false;
+        List<EntityAttributeModifier> children = new ArrayList<>();
+    }
+    
+    /**
+     * Represents a section of attribute modifiers in the tooltip
+     */
+    private static class AttributeSection {
+        final int startIndex;
+        final int lineCount;
+        final AttributeModifierSlot slot;
+        
+        AttributeSection(int startIndex, int lineCount, AttributeModifierSlot slot) {
+            this.startIndex = startIndex;
+            this.lineCount = lineCount;
+            this.slot = slot;
+        }
+    }
+} 


### PR DESCRIPTION
This PR adds **Enhanced Attribute Tooltips**, which is a feature that merges the tooltips of multiple modifiers for the same attribute on a given item stack. 

It also makes a minor but necessary change to item attribute modifier application (more on that below).

___

Here is an example of a *collapsed* tooltip for an item scaled by Dungeon Difficulty:
![image](https://github.com/user-attachments/assets/8efef614-8086-400c-b290-be07d717bf52)

While holding shift, the relevant modifier tooltips expand:
![image](https://github.com/user-attachments/assets/6802182b-fbd3-443f-bac8-a14d5ea3221b)

___

As a part of this change, item rewards **no longer merge into/replace an existing attribute modifier on the item if one is present**. 
Instead, a modifier for **only the difference in value** is added, and any merging happens **only via tooltip**. 

This has the pleasant side effect of fixing compatibility with mods like TieredZ (design incompatibilities aside - I'm sure there are cases besides TieredZ where this is more relevant):
![image](https://github.com/user-attachments/assets/edb91400-c64a-4238-b43d-afad5f615f9f)
The only seeming downsides are:
- We can't fully beautify the tooltips of items scaled by previous versions of the mod 
- If a client has this feature disabled, newly scaled items will no longer have clean "merged" modifiers at all. 
These seem to be impossible to reconcile, but the improvement far outweighs those edge cases. 

___ 

Tooltip compatibility is also maintained with Ranged Weapon API:
![image](https://github.com/user-attachments/assets/643b0086-f17d-4b9e-92c0-b9758e3691f3)

___

### Notes:
- The configuration option `enable_enhanced_attribute_tooltips` is **true** by default. 
- AttributeTooltipHandler's `applyTextFor` is a bit *hefty*. Let me know if you'd prefer it split up for code style improvements. 