### PR TITLE
Feature: Config option to disable merging attribute modifiers when applying item rewards

### DIFF
--- a/src/main/java/net/dungeon_difficulty/config/Config.java
+++ b/src/main/java/net/dungeon_difficulty/config/Config.java
@@ -8,6 +8,7 @@ public class Config {
     public class Meta { public Meta() { }
         public boolean sanitize_config = true;
         public Double rounding_unit = 0.5;
+        public boolean merge_item_modifiers = true;
     }
 
     public Announcement announcement = new Announcement();

--- a/src/main/java/net/dungeon_difficulty/logic/ItemScaling.java
+++ b/src/main/java/net/dungeon_difficulty/logic/ItemScaling.java
@@ -136,6 +136,7 @@ public class ItemScaling {
             return;
         }
         var roundingUnit = getRoundingUnit();
+        boolean useAdditiveModifiers = !DungeonDifficulty.config.value.meta.merge_item_modifiers;
 
         var attributesComponents = itemStack.get(DataComponentTypes.ATTRIBUTE_MODIFIERS);
         if (attributesComponents == null || attributesComponents.modifiers().isEmpty()) {
@@ -186,43 +187,59 @@ public class ItemScaling {
                 }
                 for (var attribute: affectedAttributes) {
                     var baseline = addValuesOf(attributesComponents, slot, attribute);
-                    var value = baseline.value;
-                    value = attributeBoost.getValue().apply((float) value);
-                    if (roundingUnit != null) {
-                        value = MathHelper.round(value, roundingUnit);
+                    var baseValue = baseline.value;
+                    
+                    if (useAdditiveModifiers) {
+                        // Additive behavior - calculate and apply only the difference
+                        var boostedValue = attributeBoost.getValue().apply((float) baseValue);
+                        var boostAmount = boostedValue - baseValue;
+                        if (roundingUnit != null) {
+                            boostAmount = MathHelper.round(boostAmount, roundingUnit);
+                        }
+                        if (boostAmount != 0) {
+                            results.get(slot).put(attribute, new ScaledAttributeResult(boostAmount));
+                        }
+                    } else {
+                        // Merge behavior - replace with scaled value
+                        var value = baseValue;
+                        value = attributeBoost.getValue().apply((float) value);
+                        if (roundingUnit != null) {
+                            value = MathHelper.round(value, roundingUnit);
+                        }
+                        results.get(slot).put(attribute, new ScaledAttributeResult(value));
                     }
-
-                    results.get(slot).put(attribute, new ScaledAttributeResult(value));
                 }
             }
         }
 
-
         var newAttributeComponent = AttributeModifiersComponent.builder();
-        for (var slot: slots) {
-            var slotResults = results.get(slot);
+        
+        for (var slot : slots) {
+            Map<RegistryEntry<EntityAttribute>, ScaledAttributeResult> slotResults = results.computeIfAbsent(slot, k -> new LinkedHashMap<>());
+            
             attributesComponents.applyModifiers(slot, (attribute, modifier) -> {
                 var result = slotResults.get(attribute);
-                if (modifier.operation() == EntityAttributeModifier.Operation.ADD_VALUE
-                    && result != null) {
-                    var id = modifier.id();
+                boolean replacing = !useAdditiveModifiers && result != null && modifier.operation() == EntityAttributeModifier.Operation.ADD_VALUE;
+                
+                if (replacing) {
                     newAttributeComponent.add(
                             attribute,
-                            new EntityAttributeModifier(id, result.value, EntityAttributeModifier.Operation.ADD_VALUE),
+                            new EntityAttributeModifier(modifier.id(), result.value, EntityAttributeModifier.Operation.ADD_VALUE),
                             AttributeModifierSlot.forEquipmentSlot(slot));
+                    slotResults.remove(attribute); 
                 } else {
+                    // Still copy the original modifier into the new component
                     newAttributeComponent.add(
                             attribute,
                             modifier,
                             AttributeModifierSlot.forEquipmentSlot(slot));
                 }
-                slotResults.remove(attribute);
             });
-            // Remainder of slot results (newly added modifiers)
-            for (var entry: slotResults.entrySet()) {
+
+            for (var entry : slotResults.entrySet()) {
                 var attribute = entry.getKey();
                 var result = entry.getValue();
-                var id = Identifier.ofVanilla("dd.boost." + slot.asString());
+                var id = Identifier.of(DungeonDifficulty.MODID, "dd.boost." + slot.asString());
                 newAttributeComponent.add(
                         attribute,
                         new EntityAttributeModifier(id, result.value, EntityAttributeModifier.Operation.ADD_VALUE),


### PR DESCRIPTION
Replaces #29, to defer potential tooltip merging to external mods. 
The configurable value `merge_item_modifiers` is **true** by default, so existing behavior is unchanged unless the user opts in.

An example, with `merge_item_modifiers` changed to false, and using an external mod to merge modifiers for the same attribute:
![image](https://github.com/user-attachments/assets/18a4575b-2568-494e-af45-956ac516fea9)

The same scaled gear, with the default configs:
![image](https://github.com/user-attachments/assets/a34dca8a-779a-46bd-be70-3fe433a748c3)
